### PR TITLE
Fix Q4_1_O on AVX2 and ARM NEON

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -7675,7 +7675,7 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
 
     // 32-byte alignment is required for _mm256_load_ps to work
     char * const temp_unaligned = ((char *) params->wdata) + sizeof(float) * ith * (ne00 + CACHE_LINE_SIZE_F32);
-    float * const temp = (float *) (temp_unaligned + ((uintptr_t) temp_unaligned) % 32);
+    float * const temp = (float *) (temp_unaligned + 32 - ((uintptr_t) temp_unaligned) % 32);
 
     if (ne11 != 1) {
         fprintf(stderr, "Non-vectors are not supported as a second argument for ggml_compute_forward_mul_mat_q4_1_o_f32\n");

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -7545,6 +7545,7 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
               struct ggml_tensor * dst) {
     int64_t t0 = ggml_perf_time_us();
     UNUSED(t0);
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
 
     const int64_t ne00 = src0->ne[0];
     const int64_t ne01 = src0->ne[1];
@@ -7605,7 +7606,9 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
     //   compute by src0 rows
 
 #if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS)
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
     if (ggml_compute_forward_mul_mat_use_blas(src0, src1, dst)) {
+        fprintf(stderr, "[ggml] %d\n", __LINE__);
         if (params->ith != 0) {
             return;
         }
@@ -7625,6 +7628,7 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
                 {
                     size_t id = 0;
                     for (int64_t i01 = 0; i01 < ne01; ++i01) {
+                        fprintf(stderr, "[ggml] %d\n", __LINE__);
                         dequantize_row_q4_1_o((char *) src0->data + i03*nb03 + i02*nb02 + i01*nb01, wdata + id, ne00);
                         id += ne00;
                     }
@@ -7634,6 +7638,8 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
                 const float * y = (float *) ((char *) src1->data + i02*nb12 + i03*nb13);
 
                 float * d = (float *) ((char *) dst->data + i02*nb2 + i03*nb3);
+
+                fprintf(stderr, "[ggml] %d\n", __LINE__);
 
                 // zT = y * xT
                 cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
@@ -7658,6 +7664,8 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
         return;
     }
 
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
+
     // parallelize by src0 rows using ggml_vec_dot_f32
 
     // total rows in src0
@@ -7671,9 +7679,15 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
     const int ir1 = MIN(ir0 + dr, nr);
 
 #if defined(__AVX2__)
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
+
     const int block_count = ne00 / QK4_1_O;
 
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
+
     float * const temp = ((float *) params->wdata) + ith * (ne00 + CACHE_LINE_SIZE_F32);
+
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
 
     if (ne11 != 1) {
         fprintf(stderr, "Non-vectors are not supported as a second argument for ggml_compute_forward_mul_mat_q4_1_o_f32\n");
@@ -7681,8 +7695,12 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
         abort();
     }
 
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
+
     // Copy vector into a temporary buffer
     memcpy(temp, (char *) src1->data, ne00 * sizeof(float));
+
+    fprintf(stderr, "[ggml] %d\n", __LINE__);
 #endif
 
     for (int ir = ir0; ir < ir1; ++ir) {
@@ -7703,8 +7721,10 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
             const int i1 = i11;
             const int i2 = i02;
             const int i3 = i03;
+            fprintf(stderr, "[ggml] %d\n", __LINE__);
 
             const block_q4_1_o * row_blocks = (block_q4_1_o *) ((char *) src0->data + (i01 * nb01 + i02 * nb02 + i03 * nb03));
+            fprintf(stderr, "[ggml] %d\n", __LINE__);
 
             __m256 accum = _mm256_setzero_ps();
 
@@ -7765,6 +7785,7 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
                 accum = _mm256_fmadd_ps(src1_2, weight_2, accum);
                 accum = _mm256_fmadd_ps(src1_3, weight_3, accum);
             }
+            fprintf(stderr, "[ggml] %d\n", __LINE__);
 
             // Add elements of accumulator
             __m128 res = _mm256_extractf128_ps(accum, 1);
@@ -7773,11 +7794,14 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
             res = _mm_add_ss(res, _mm_movehdup_ps(res));
 
             *((float *) ((char *) dst->data + (i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3))) = _mm_cvtss_f32(res) + outlier_accum;
+            fprintf(stderr, "[ggml] %d\n", __LINE__);
         }
 #else
         float * const wdata = (float *) ((char *) params->wdata + (i01 * nb01 + i02 * nb02 + i03 * nb03));
+        fprintf(stderr, "[ggml] %d\n", __LINE__);
 
         dequantize_row_q4_1_o((char *) src0->data + (i01 * nb01 + i02 * nb02 + i03 * nb03), wdata, ne00);
+        fprintf(stderr, "[ggml] %d\n", __LINE__);
 
         for (int ic = 0; ic < ne11; ++ic) {
             // src1 indices
@@ -7791,13 +7815,16 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
             const int i2 = i02;
             const int i3 = i03;
 
+            fprintf(stderr, "[ggml] %d\n", __LINE__);
             ggml_vec_dot_f32(
                     ne00,
                     (float *) ((char *) dst->data + (i0 * nb0 + i1 * nb1 + i2 * nb2 + i3 * nb3)),
                     wdata,
                     (float *) ((char *) src1->data + (i11 * nb11 + i12 * nb12 + i13 * nb13))
             );
+            fprintf(stderr, "[ggml] %d\n", __LINE__);
         }
+        fprintf(stderr, "[ggml] %d\n", __LINE__);
 #endif
     }
 }

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -7546,20 +7546,20 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
     int64_t t0 = ggml_perf_time_us();
     UNUSED(t0);
 
-    const int ne00 = src0->ne[0];
-    const int ne01 = src0->ne[1];
-    const int ne02 = src0->ne[2];
-    const int ne03 = src0->ne[3];
+    const int64_t ne00 = src0->ne[0];
+    const int64_t ne01 = src0->ne[1];
+    const int64_t ne02 = src0->ne[2];
+    const int64_t ne03 = src0->ne[3];
 
-    const int ne10 = src1->ne[0];
-    const int ne11 = src1->ne[1];
-    const int ne12 = src1->ne[2];
-    const int ne13 = src1->ne[3];
+    const int64_t ne10 = src1->ne[0];
+    const int64_t ne11 = src1->ne[1];
+    const int64_t ne12 = src1->ne[2];
+    const int64_t ne13 = src1->ne[3];
 
-    const int ne0  = dst->ne[0];
-    const int ne1  = dst->ne[1];
-    const int ne2  = dst->ne[2];
-    const int ne3  = dst->ne[3];
+    const int64_t ne0  = dst->ne[0];
+    const int64_t ne1  = dst->ne[1];
+    const int64_t ne2  = dst->ne[2];
+    const int64_t ne3  = dst->ne[3];
 
     const int nb00 = src0->nb[0];
     const int nb01 = src0->nb[1];
@@ -7620,11 +7620,11 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
 
         float * const wdata = params->wdata;
 
-        for (int i03 = 0; i03 < ne03; i03++) {
-            for (int i02 = 0; i02 < ne02; i02++) {
+        for (int64_t i03 = 0; i03 < ne03; i03++) {
+            for (int64_t i02 = 0; i02 < ne02; i02++) {
                 {
                     size_t id = 0;
-                    for (int i01 = 0; i01 < ne01; ++i01) {
+                    for (int64_t i01 = 0; i01 < ne01; ++i01) {
                         dequantize_row_q4_1_o((char *) src0->data + i03*nb03 + i02*nb02 + i01*nb01, wdata + id, ne00);
                         id += ne00;
                     }
@@ -7639,7 +7639,7 @@ static void ggml_compute_forward_mul_mat_q4_1_o_f32(
                 cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
                         ne11, ne01, ne10,
                         1.0f,    y, ne10,
-                                 x, ne10,
+                                 x, ne00,
                         0.0f,    d, ne01);
             }
         }

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -1602,8 +1602,8 @@ static void dequantize_row_q4_1_o(const void * restrict vx, float * restrict y, 
             const uint8x16_t vq = vcombine_u8(vx_0, vx_1);
 
             // convert to 2x uint16x8_t
-            const uint16x8_t vi_0 = vmovl_s8(vget_low_u8 (vq));
-            const uint16x8_t vi_1 = vmovl_s8(vget_high_u8(vq));
+            const uint16x8_t vi_0 = vmovl_u8(vget_low_u8 (vq));
+            const uint16x8_t vi_1 = vmovl_u8(vget_high_u8(vq));
 
             // convert to 4x float32x4_t
             const float32x4_t vf_0 = vcvtq_f32_u32(vmovl_u16(vget_low_u16 (vi_0)));


### PR DESCRIPTION
Changes made:
- align temp vector when doing matmul on AVX2
- use `vmovl_u8` instead of `vmovl_s8` when dequantizing on ARM NEON